### PR TITLE
Fix Spotify checker CORS issue

### DIFF
--- a/docs/tools/spotifychecker/index.html
+++ b/docs/tools/spotifychecker/index.html
@@ -208,7 +208,8 @@
           progress.style.width = `${((i + 1) / tracks.length) * 100}%`;
           await new Promise((resolve) => setTimeout(resolve, 200));
 
-          const res = await fetch(`https://synthriderz.com/api/beatmaps?q=${encodeURIComponent(track.name)}&sort=published_at,DESC`);
+          const apiUrl = `https://synthriderz.com/api/beatmaps?q=${encodeURIComponent(track.name)}&sort=published_at,DESC`;
+          const res = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(apiUrl)}`);
           const results = await res.json();
           span.classList.remove("checking");
           if (Array.isArray(results) && results.length > 0) {


### PR DESCRIPTION
## Summary
- fix the beatmap lookup to go through allorigins CORS proxy

## Testing
- `npm run lint-code` *(fails: ESLint couldn't find a config)*
- `npx prettier -w docs/tools/spotifychecker/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6852484f7f9c832eb491567e554e32fb